### PR TITLE
[#eng-3379] Fix the order in which config files are loaded and merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,17 @@ Or:
 
 Only the provided values will be overwritten.
 
+## Mind the Classpath
+
+Carica looks for resources on the classpath and merges them in order,
+meaning that configuration files earlier in the classpath will take
+precedence over those that come later.
+
+When using Leiningen the classpath is built such that test comes
+first, then src, followed by resources-path. Keep the order in mind
+when dealing with multiple configuration files with Leiningen and when
+building the classpath by hand.
+
 ## License
 
 Copyright (C) 2012 Sonian, Inc.

--- a/src/carica/core.clj
+++ b/src/carica/core.clj
@@ -8,12 +8,11 @@
   "Search the classpath for resources matching the given path"
   [path]
   (when path
-    (reverse
-     (enumeration-seq
-      (.getResources
-       (.getContextClassLoader
-        (Thread/currentThread))
-       path)))))
+    (enumeration-seq
+     (.getResources
+      (.getContextClassLoader
+       (Thread/currentThread))
+      path))))
 
 (defn merge-nested [v1 v2]
   (if (and (map? v1) (map? v2))

--- a/test/carica/test/core.clj
+++ b/test/carica/test/core.clj
@@ -10,9 +10,10 @@
       (testing "with the ability to get at nested values"
         (is (= "test-clj" (config :nested-one-clj :test-clj)))))
     (testing "should merge all maps on the classpath"
+      (is (= true (config :from-test)))
       (is (= true (config :from-etc)))
       (testing "but the first on the classpath should win"
-        (is (= "etc" (config :merged-val)))))
+        (is (= "test" (config :merged-val)))))
     (testing "should be overridden with override-config"
       (with-redefs [config (override-config
                             {:nested-multi-json {:test-json {:test-json 21}

--- a/test/config.clj
+++ b/test/config.clj
@@ -1,5 +1,4 @@
-{:from-etc false
- :from-test true
+{:from-test true
 
  :nil-val nil
 


### PR DESCRIPTION
Previously it was reversed but now it will follow standard classpath
precedence rules. That is, the first config file found in the
classpath will override those that come after.

Updated tests and readme.
