### PR TITLE
make it possible to expose extra info from config middleware

### DIFF
--- a/test/carica/test/core.clj
+++ b/test/carica/test/core.clj
@@ -95,3 +95,21 @@
     (testing "Eval works"
       (is (= '(+ 1 1) (empty-cfg :eval-cfg)))
       (is (= 2 (eval-cfg :eval-cfg))))))
+
+(deftest test-arrows
+  (let [call-count (atom 0)
+        call-mdlware (fn [f]
+                       (fn [resources]
+                         (swap! call-count inc)
+                         (f resources)))
+        cached-cfg (configurer (resources "config.clj")
+                               [call-mdlware cache-config])
+        eval-cfg (configurer (resources "config.clj")
+                             [eval-config])]
+    (testing "Resetting cache works"
+      (is (= true (cached-cfg :from-test)))
+      (is (= true (cached-cfg :from-test)))
+      (is (= 1 @call-count))
+      (swap! (cached-cfg :carica/middleware :carica/mem) empty)
+      (is (= true (cached-cfg :from-test)))
+      (is (= 2 @call-count)))))


### PR DESCRIPTION
for example expose the memo atom used in memoizing config to make it
possible to reset it
