### PR TITLE
Fixed reflection warnings (.getPath and .openStream)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,8 @@
                  [org.clojure/tools.reader "0.8.3"]]
   :profiles {:dev
              {:resource-paths ["etc"]
-              :dependencies [[org.clojure/clojure "1.5.1"]]}
+              :dependencies [[org.clojure/clojure "1.6.0"]]}
+             :1.5.1 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}}
   :aliases {"all" ["with-profile" "dev:1.4,dev"]}
   ;; For Lein 1

--- a/src/carica/core.clj
+++ b/src/carica/core.clj
@@ -53,7 +53,7 @@
   (fn [resource]
     (->> (if (string? resource)
            resource
-           (.getPath resource))
+           (.getPath ^java.io.File resource))
          (re-find #"\.([^..]*?)$")
          second
          (keyword "carica"))))
@@ -65,7 +65,7 @@
   (load-with resource clj-reader/read))
 
 (defmethod load-config :carica/json [resource]
-  (with-open [s (.openStream resource)]
+  (with-open [s (.openStream ^java.net.URL resource)]
     (-> s reader (json-parse-stream true))))
 
 (derive :carica/clj :carica/edn)


### PR DESCRIPTION
Carica doesn't use reflection anymore now.
