### PR TITLE
Deep merge env override middleware

### DIFF
--- a/src/carica/core.clj
+++ b/src/carica/core.clj
@@ -1,5 +1,6 @@
 (ns carica.core
-  (:require [carica.middleware :as mw]
+  (:require [carica.map :refer [merge-nested]]
+            [carica.middleware :as mw]
             [clojure.java.io :as io]
             [clojure.tools.logging :as log]
             [clojure.tools.reader :as clj-reader]
@@ -32,13 +33,6 @@
       (.getContextClassLoader
        (Thread/currentThread))
       path))))
-
-(defn merge-nested
-  "Recursively merge two Clojure trees of maps."
-  [v1 v2]
-  (if (and (map? v1) (map? v2))
-    (merge-with merge-nested v1 v2)
-    v2))
 
 (defn load-with [resource loader]
   (try

--- a/src/carica/map.clj
+++ b/src/carica/map.clj
@@ -1,0 +1,8 @@
+(ns carica.map)
+
+(defn merge-nested
+  "Recursively merge two Clojure trees of maps."
+  [v1 v2]
+  (if (and (map? v1) (map? v2))
+    (merge-with merge-nested v1 v2)
+    v2))

--- a/src/carica/middleware.clj
+++ b/src/carica/middleware.clj
@@ -1,5 +1,6 @@
 (ns carica.middleware
-  (:require [clojure.tools.logging :as log]))
+  (:require [carica.map :refer [merge-nested]]
+            [clojure.tools.logging :as log]))
 
 (defn get-config-fn
   "Retrieve the wrapped fn from the middleware, or return f if
@@ -124,5 +125,5 @@
          (let [cfg-map (f resources)
                env-cfg (get-in cfg-map env-path)]
            (if (and env (map? env-cfg))
-             (merge cfg-map env-cfg)
+             (merge-nested cfg-map env-cfg)
              cfg-map)))))))

--- a/test/carica/test/middleware.clj
+++ b/test/carica/test/middleware.clj
@@ -57,7 +57,8 @@
                           (resources "config.clj")
                           [(env-override-config "NOOP" :env-config)])]
           (is (= "please" (env-config :magic-word)))
-          (is (= "sugar on top" (env-config :extra)))))
+          (is (= "sugar on top" (env-config :extra)))
+          (is (= 2 (env-config :test :nested :map)))))
       (testing "a different env"
         (reset! env "dev")
         (let [env-config (configurer

--- a/test/config.clj
+++ b/test/config.clj
@@ -17,8 +17,10 @@
 
  :magic-word "mellon"
 
- :prod {:magic-word "hocus pocus"}
+ :prod {:magic-word "hocus pocus"
+        :test {:nested {:map 1}}}
 
  :env-config {:dev {:magic-word "abrakadabra"}
               :prod {:magic-word "please"
-                     :extra "sugar on top"}}}
+                     :extra "sugar on top"
+                     :test {:nested {:map 2}}}}}


### PR DESCRIPTION
I've replaced `merge` in the env-override function with `merge-nested` so that the behaviour is now the same as inter-config merges :)

`nested-merge` is also now shared so I've moved it into a different namespace: `map.clj`.

Updated one of the test cases.