### PR TITLE
Env substitute config middleware

### DIFF
--- a/src/carica/middleware.clj
+++ b/src/carica/middleware.clj
@@ -127,3 +127,27 @@
            (if (and env (map? env-cfg))
              (merge-nested cfg-map env-cfg)
              cfg-map)))))))
+
+(defn env-substitute-config
+  "Middleware that will override a known key with the value of an environment
+  variable.
+
+  Given this config map:
+  {:something 1
+   :otherthing 2}
+
+  Given this middleware definition:
+  (env-substitute-config \"MY_OTHER_THING\" :otherthing)
+
+  Given an execution environment with a definition like this
+  export MY_OTHER_THING=5
+
+  This config will result:
+  {:something 1
+   :otherthing 5}"
+  [env-var-name & keyseq]
+  (let [env-val (getenv env-var-name)]
+    (fn [f]
+      (fn [resources]
+        (let [cfg-map (f resources)]
+          (assoc-in cfg-map keyseq env-val))))))

--- a/test/carica/test/middleware.clj
+++ b/test/carica/test/middleware.clj
@@ -80,3 +80,16 @@
                           [(env-override-config "NOOP")])]
           (is (= "hocus pocus" (env-config :magic-word)))
           (is (nil? (env-config :extra))))))))
+
+(deftest test-env-substitute-config
+  (with-redefs [getenv (constantly "Now.")]
+    (testing "the envvar value is in the location"
+      (let [env-config (configurer
+                        (resources "config.clj")
+                        [(env-substitute-config "NOOP" :magic-word)
+                         (env-substitute-config "NOOP"
+                                                :i-totally :dont-exist)])]
+        (is (= "Now." (env-config :magic-word))
+            "Should see our overridden value.")
+        (is (= "Now." (env-config :i-totally :dont-exist))
+            "Nested key paths should work, even if they aren't defined.")))))


### PR DESCRIPTION
```
‹ ~/src/sonian/carica › λ export FOOBAR="baz"
‹ ~/src/sonian/carica › λ lein repl
user=> (require '[carica.core :as carica])
user=> (require '[carica.middleware :as mw])
user=> (def config (carica/configurer (concat (carica/resources "config.json") (carica/resources "config.edn") (carica/resources "config.clj")) (conj carica/default-middleware (mw/env-substitute-config "FOOBAR" :flibber))))
#'user/config
user=> (config :flibber)
"baz"
```
