### PR TITLE
Unset envvar subs dont overwrite with nils

### DIFF
--- a/src/carica/middleware.clj
+++ b/src/carica/middleware.clj
@@ -150,4 +150,6 @@
     (fn [f]
       (fn [resources]
         (let [cfg-map (f resources)]
-          (assoc-in cfg-map keyseq env-val))))))
+          (if-not (nil? env-val)
+            (assoc-in cfg-map keyseq env-val)
+            cfg-map))))))

--- a/test/carica/test/middleware.clj
+++ b/test/carica/test/middleware.clj
@@ -82,8 +82,8 @@
           (is (nil? (env-config :extra))))))))
 
 (deftest test-env-substitute-config
-  (with-redefs [getenv (constantly "Now.")]
-    (testing "the envvar value is in the location"
+  (testing "the envvar value is in the location"
+    (with-redefs [getenv (constantly "Now.")]
       (let [env-config (configurer
                         (resources "config.clj")
                         [(env-substitute-config "NOOP" :magic-word)
@@ -92,4 +92,11 @@
         (is (= "Now." (env-config :magic-word))
             "Should see our overridden value.")
         (is (= "Now." (env-config :i-totally :dont-exist))
-            "Nested key paths should work, even if they aren't defined.")))))
+            "Nested key paths should work, even if they aren't defined."))))
+  (testing "a missing envvar returns the configured default"
+    (with-redefs [getenv (constantly nil)]
+      (let [env-config (configurer
+                        (resources "config.clj")
+                        [(env-substitute-config "NOOP" :magic-word)])]
+        (is (= "mellon" (env-config :magic-word))
+            "Should see our configured default value.")))))


### PR DESCRIPTION
Although I didn't need this for the thing I wanted the original feature for, it occurred to me while using it that there's certainly a use case for overriding an _existing_ default via environment, and the first implementation couldn't do that. If you didn't set the envvar, it always returned `nil` for the config coordinates, even if you had something set there in the file on disk.

Also, I got to use `paredit-convolute-sexp` while tweaking the tests, which means I am having a spectacular morning already.