### PR TITLE
Update dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (defproject sonian/carica "1.2.4-SNAPSHOT"
   :description "A flexible configuration library"
   :url "https://github.com/sonian/carica"
-  :dependencies [[cheshire "5.3.1"]
+  :dependencies [[cheshire "5.11.0"]
                  [org.clojure/tools.logging "1.2.4"]
                  [org.clojure/tools.reader "1.3.6"]]
   :profiles {:dev

--- a/project.clj
+++ b/project.clj
@@ -1,12 +1,12 @@
-(defproject sonian/carica "1.2.3-SNAPSHOT"
+(defproject sonian/carica "1.2.4-SNAPSHOT"
   :description "A flexible configuration library"
   :url "https://github.com/sonian/carica"
   :dependencies [[cheshire "5.3.1"]
-                 [org.clojure/tools.logging "0.2.6"]
-                 [org.clojure/tools.reader "0.8.3"]]
+                 [org.clojure/tools.logging "1.2.4"]
+                 [org.clojure/tools.reader "1.3.6"]]
   :profiles {:dev
              {:resource-paths ["etc"]
-              :dependencies [[org.clojure/clojure "1.5.1"]]}
+              :dependencies [[org.clojure/clojure "1.10.3"]]}
              :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}}
   :aliases {"all" ["with-profile" "dev:1.4,dev"]}
   ;; For Lein 1


### PR DESCRIPTION
 FROM
cheshire "5.3.1" - Jan, 2014
org.clojure/tools.logging "0.2.6" - Feb, 2013
org.clojure/tools.reader "0.8.3" - Dec, 2013
TO
cheshire "5.11.0" - May, 2022
org.clojure/tools.logging "1.2.4" - Jan, 2022
org.clojure/tools.reader "1.3.6" - Jul, 2021